### PR TITLE
4 tqdm dependency issue

### DIFF
--- a/data_visualization/Create_GIF.py
+++ b/data_visualization/Create_GIF.py
@@ -1,4 +1,3 @@
-from tqdm.notebook import tqdm
 from PIL import Image
 from .gen_frame import *
 
@@ -27,7 +26,7 @@ def Create_GIF(filename, path, num_images, duration = 66, loop = None):
     frames = []
     
     print("Genrating Frame Data")
-    for i in tqdm(range(num_images)):
+    for i in range(num_images))
         frames.append(gen_frame(path + f"{filename}_{i}.png"))
         
     print("Saving gif...")

--- a/data_visualization/__init__.py
+++ b/data_visualization/__init__.py
@@ -29,4 +29,4 @@ import matplotlib as mpl
 mpl.rcParams["axes.facecolor"]   = "none"
 mpl.rcParams["figure.facecolor"] = "none"
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"


### PR DESCRIPTION
removed tqdm from create gif. It was not required as part of the install and is superfluous.